### PR TITLE
Update e.json

### DIFF
--- a/src/technologies/e.json
+++ b/src/technologies/e.json
@@ -290,8 +290,7 @@
     },
     "description": "ElasticSuite is a merchandising suite for Magento and OroCommerce.",
     "html": [
-      "<input [^>]*Smile_Elasticsuite[^>]*>",
-      "<[\\S\\s.*]*Smile_Elasticsuite[\\S\\s.*]*>"
+      "<[^>]*Smile_Elasticsuite[^>]*>"
     ],
     "icon": "ElasticSuite.svg",
     "implies": [


### PR DESCRIPTION
The current `[\S\s.*]*` groups in ElasticSuite's second html regex match the entire html document (all non-whitespace, whitespace, literal . and *) and basically full text search Smile_Elasticsuite on the entire page. I don't think that was intended, since the pattern is surrounded by < >. Instead, I extended the first pattern from just <input> tags to all html tags.